### PR TITLE
DBM: add sliders for icon X-offset and bartext Y-offset + more scrollbar skinning

### DIFF
--- a/ElvUI_AddOnSkins/Locales/deDE.lua
+++ b/ElvUI_AddOnSkins/Locales/deDE.lua
@@ -3,12 +3,14 @@ local L = E.Libs.ACL:NewLocale("ElvUI", "deDE")
 
 L["AddOn Skins"] = true
 L["AuraBar Backdrop"] = true
+L["Bar Text Y-Offset"] = true
 L["DBM Half-bar Skin"] = "DBM Halbeleisten Skin"
 L["Default"] = true
 L["Double"] = true
 L["Embed Type"] = true
 L["Font Size"] = true
 L["Icon Cooldown"] = true
+L["Icon X-Offset"] = true
 L["Left Panel"] = true
 L["Left Window Width"] = true
 L["Misc Options"] = true

--- a/ElvUI_AddOnSkins/Locales/enUS.lua
+++ b/ElvUI_AddOnSkins/Locales/enUS.lua
@@ -3,12 +3,14 @@ local L = E.Libs.ACL:NewLocale("ElvUI", "enUS", true, true)
 
 L["AddOn Skins"] = true
 L["AuraBar Backdrop"] = true
+L["Bar Text Y-Offset"] = true
 L["DBM Half-bar Skin"] = true
 L["Default"] = true
 L["Double"] = true
 L["Embed Type"] = true
 L["Font Size"] = true
 L["Icon Cooldown"] = true
+L["Icon X-Offset"] = true
 L["Left Panel"] = true
 L["Left Window Width"] = true
 L["Misc Options"] = true

--- a/ElvUI_AddOnSkins/Locales/esMX.lua
+++ b/ElvUI_AddOnSkins/Locales/esMX.lua
@@ -3,12 +3,14 @@ local L = E.Libs.ACL:NewLocale("ElvUI", "esMX")
 
 L["AddOn Skins"] = true
 L["AuraBar Backdrop"] = true
+L["Bar Text Y-Offset"] = true
 L["DBM Half-bar Skin"] = true
 L["Default"] = true
 L["Double"] = true
 L["Embed Type"] = true
 L["Font Size"] = true
 L["Icon Cooldown"] = true
+L["Icon X-Offset"] = true
 L["Left Panel"] = true
 L["Left Window Width"] = true
 L["Misc Options"] = true

--- a/ElvUI_AddOnSkins/Locales/frFR.lua
+++ b/ElvUI_AddOnSkins/Locales/frFR.lua
@@ -3,12 +3,14 @@ local L = E.Libs.ACL:NewLocale("ElvUI", "frFR")
 
 L["AddOn Skins"] = "Skins d'AddOn"
 L["AuraBar Backdrop"] = true
+L["Bar Text Y-Offset"] = true
 L["DBM Half-bar Skin"] = "Skin Demi-Bar pour DBM"
 L["Default"] = true
 L["Double"] = true
 L["Embed Type"] = true
 L["Font Size"] = true
 L["Icon Cooldown"] = true
+L["Icon X-Offset"] = true
 L["Left Panel"] = true
 L["Left Window Width"] = true
 L["Misc Options"] = true

--- a/ElvUI_AddOnSkins/Locales/koKR.lua
+++ b/ElvUI_AddOnSkins/Locales/koKR.lua
@@ -3,12 +3,14 @@ local L = E.Libs.ACL:NewLocale("ElvUI", "koKR")
 
 L["AddOn Skins"] = true
 L["AuraBar Backdrop"] = true
+L["Bar Text Y-Offset"] = true
 L["DBM Half-bar Skin"] = true
 L["Default"] = true
 L["Double"] = true
 L["Embed Type"] = true
 L["Font Size"] = true
 L["Icon Cooldown"] = true
+L["Icon X-Offset"] = true
 L["Left Panel"] = true
 L["Left Window Width"] = true
 L["Misc Options"] = true

--- a/ElvUI_AddOnSkins/Locales/ptBR.lua
+++ b/ElvUI_AddOnSkins/Locales/ptBR.lua
@@ -3,12 +3,14 @@ local L = E.Libs.ACL:NewLocale("ElvUI", "ptBR")
 
 L["AddOn Skins"] = true
 L["AuraBar Backdrop"] = true
+L["Bar Text Y-Offset"] = "Deslocamento vertical do texto da barra"
 L["DBM Half-bar Skin"] = "Skin Meia-barra para DBM"
 L["Default"] = true
 L["Double"] = true
 L["Embed Type"] = true
 L["Font Size"] = true
 L["Icon Cooldown"] = true
+L["Icon X-Offset"] = "Deslocamento horizontal do ícone"
 L["Left Panel"] = true
 L["Left Window Width"] = true
 L["Misc Options"] = true

--- a/ElvUI_AddOnSkins/Locales/ruRU.lua
+++ b/ElvUI_AddOnSkins/Locales/ruRU.lua
@@ -3,12 +3,14 @@ local L = E.Libs.ACL:NewLocale("ElvUI", "ruRU")
 
 L["AddOn Skins"] = "Скины аддонов"
 L["AuraBar Backdrop"] = true
+L["Bar Text Y-Offset"] = true
 L["DBM Half-bar Skin"] = "DBM режим тонких полос"
 L["Default"] = true
 L["Double"] = "Двойной"
 L["Embed Type"] = "Тип встраивания"
 L["Font Size"] = true
 L["Icon Cooldown"] = true
+L["Icon X-Offset"] = true
 L["Left Panel"] = "Левое окно"
 L["Left Window Width"] = "Ширина левого окна"
 L["Misc Options"] = true

--- a/ElvUI_AddOnSkins/Locales/zhCN.lua
+++ b/ElvUI_AddOnSkins/Locales/zhCN.lua
@@ -3,12 +3,14 @@ local L = E.Libs.ACL:NewLocale("ElvUI", "zhCN")
 
 L["AddOn Skins"] = "插件皮肤"
 L["AuraBar Backdrop"] = "光环条背景"
+L["Bar Text Y-Offset"] = true
 L["DBM Half-bar Skin"] = "DBM 半高计时条"
 L["Default"] = "默认"
 L["Double"] = "双内嵌"
 L["Embed Type"] = "内嵌样式"
 L["Font Size"] = "字体大小"
 L["Icon Cooldown"] = "图标冷却"
+L["Icon X-Offset"] = true
 L["Left Panel"] = "左面板"
 L["Left Window Width"] = "左窗口宽度"
 L["Misc Options"] = "其它选项"

--- a/ElvUI_AddOnSkins/Locales/zhTW.lua
+++ b/ElvUI_AddOnSkins/Locales/zhTW.lua
@@ -3,12 +3,14 @@ local L = E.Libs.ACL:NewLocale("ElvUI", "zhTW")
 
 L["AddOn Skins"] = "插件美化"
 L["AuraBar Backdrop"] = true
+L["Bar Text Y-Offset"] = true
 L["DBM Half-bar Skin"] = "DBM 計時條美化"
 L["Default"] = true
 L["Double"] = true
 L["Embed Type"] = true
 L["Font Size"] = true
 L["Icon Cooldown"] = true
+L["Icon X-Offset"] = true
 L["Left Panel"] = true
 L["Left Window Width"] = true
 L["Misc Options"] = true

--- a/ElvUI_AddOnSkins/Settings/Profile.lua
+++ b/ElvUI_AddOnSkins/Settings/Profile.lua
@@ -17,9 +17,11 @@ P.addOnSkins = {
 	omenTitleTemplateGloss = true,
 
 	dbmBarHeight = 22,
+	dbmBarTextYOffset = 3,
 	dbmFont = "PT Sans Narrow",
 	dbmFontSize = 12,
 	dbmFontOutline = "OUTLINE",
+	dbmIconXOffset = E.Border + E.Spacing,
 	dbmIconSize = 1,
 	dbmTemplate = "Default",
 	DBMSkinHalf = false,

--- a/ElvUI_AddOnSkins/Skins/Addons/dbm.lua
+++ b/ElvUI_AddOnSkins/Skins/Addons/dbm.lua
@@ -518,6 +518,12 @@ S:AddCallbackForAddon("DBM-GUI", "DBM-GUI", function()
 			S:HandleCollapseTexture(button.toggle)
 		end
 
+		-- Panel Container FOV Scrollbar backdrop
+		local child = select(3, DBM_GUI_OptionsFramePanelContainerFOVScrollBar:GetChildren())
+		if child and child:IsObjectType("Frame") then
+			child:StripTextures()
+		end
+
 		-- Dropdown list & scrollbar
 		DBM_GUI_DropDownList:StripTextures() -- removes UI-Tooltip-Border
 		S:HandleScrollBar(DBM_GUI_DropDownListScrollBar) -- original position and size are ruined, so rebuild them below
@@ -532,6 +538,8 @@ S:AddCallbackForAddon("DBM-GUI", "DBM-GUI", function()
 		if backportVersion2 then
 			DBM_GUI_OptionsFrameList:StripTextures()
 			DBM_GUI_OptionsFrameList:SetTemplate("Transparent")
+
+			DBM_GUI_OptionsFrameListList:StripTextures()
 			S:HandleScrollBar(DBM_GUI_OptionsFrameListListScrollBar)
 			DBM_GUI_OptionsFrameListListScrollBar:Point("TOPRIGHT", 1, -18)
 			DBM_GUI_OptionsFrameListListScrollBar:Point("BOTTOMLEFT", 7, 18)

--- a/ElvUI_AddOnSkins/Skins/Addons/dbm.lua
+++ b/ElvUI_AddOnSkins/Skins/Addons/dbm.lua
@@ -21,19 +21,20 @@ S:AddCallbackForAddon("DBM-Core", "DBM-Core", function()
 	local backportVersion2 = DBM.ReleaseRevision >= 20220412000000 -- 9.2.14
 
 	local function createIconOverlay(id, parent)
+		local db = E.db.addOnSkins
 		local frame = CreateFrame("Frame", "$parentIcon" .. id .. "Overlay", parent)
 		frame:SetTemplate()
 
 		if id == 1 then
-			if E.db.addOnSkins.DBMSkinHalf then
-				frame:Point("BOTTOMRIGHT", parent, "BOTTOMLEFT", -10 * (E.Border + E.Spacing), 0)
+			if db.DBMSkinHalf then
+				frame:Point("BOTTOMRIGHT", parent, "BOTTOMLEFT", - db.dbmIconXOffset, 0)
 			else
-				frame:Point("RIGHT", parent, "LEFT", -(E.Border + E.Spacing), 0)
+				frame:Point("RIGHT", parent, "LEFT", - db.dbmIconXOffset, 0)
 			end
-		elseif E.db.addOnSkins.DBMSkinHalf then
-			frame:Point("BOTTOMLEFT", parent, "BOTTOMRIGHT", 10 * (E.Border + E.Spacing), 0)
+		elseif db.DBMSkinHalf then
+			frame:Point("BOTTOMLEFT", parent, "BOTTOMRIGHT", db.dbmIconXOffset, 0)
 		else
-			frame:Point("LEFT", parent, "RIGHT", (E.Border + E.Spacing), 0)
+			frame:Point("LEFT", parent, "RIGHT", db.dbmIconXOffset, 0)
 		end
 
 		local backdroptex = frame:CreateTexture(nil, "BORDER")
@@ -196,7 +197,7 @@ S:AddCallbackForAddon("DBM-Core", "DBM-Core", function()
 					timer:SetShadowColor(0, 0, 0, 0)
 
 					if db.DBMSkinHalf then
-						name:SetPoint("BOTTOMLEFT", frame, "TOPLEFT", 0, 3)
+						name:SetPoint("BOTTOMLEFT", frame, "TOPLEFT", 0, db.dbmBarTextYOffset)
 						name:SetPoint("BOTTOMRIGHT", timer, "BOTTOMLEFT") -- truncation
 						timer:SetPoint("BOTTOMRIGHT", frame, "TOPRIGHT", -1, 1)
 					else

--- a/ElvUI_AddOnSkins/core.lua
+++ b/ElvUI_AddOnSkins/core.lua
@@ -375,8 +375,15 @@ local function getOptions()
 								name = "Bar Height",
 								hidden = function() return DBM.ReleaseRevision > 7000 end
 							},
-							dbmFont = {
+							dbmBarTextYOffset = {
 								order = 2,
+								type = "range",
+								min = -5, max = 10, step = 1,
+								name = L["Bar Text Y-Offset"],
+								disabled = function() return not E.db.addOnSkins.DBMSkinHalf end
+							},
+							dbmFont = {
+								order = 3,
 								type = "select",
 								dialogControl = "LSM30_Font",
 								name = L["Font"],
@@ -384,14 +391,14 @@ local function getOptions()
 								hidden = function() return DBM.ReleaseRevision > 7000 end
 							},
 							dbmFontSize = {
-								order = 3,
+								order = 4,
 								type = "range",
 								min = 6, max = 22, step = 1,
 								name = L["Font Size"],
 								hidden = function() return DBM.ReleaseRevision > 7000 end
 							},
 							dbmFontOutline = {
-								order = 4,
+								order = 5,
 								type = "select",
 								name = L["Font Outline"],
 								values = {
@@ -403,19 +410,26 @@ local function getOptions()
 								hidden = function() return DBM.ReleaseRevision > 7000 end
 							},
 							dbmIconSize = {
-								order = 5,
+								order = 6,
 								type = "range",
 								min = 0.1, max = 2, step = 0.1,
 								name = L["Icon Size"],
 							},
+							dbmIconXOffset = {
+								order = 7,
+								type = "range",
+								min = -10, max = 10, step = 1,
+								name = L["Icon X-Offset"],
+								set = function(info, value) E.db.addOnSkins[info[#info]] = value E:StaticPopup_Show("PRIVATE_RL") end -- dbm skin should probably be recoded to avoid a UI reload for this option to apply.
+							},
 							dbmTemplate = {
-								order = 6,
+								order = 8,
 								type = "select",
 								name = L["Template"],
 								values = backdropValues
 							},
 							DBMSkinHalf = {
-								order = 7,
+								order = 9,
 								type = "toggle",
 								name = L["DBM Half-bar Skin"]
 							}


### PR DESCRIPTION
Icon X-offset requires a reload due to how the dbm skin is written. Maybe in the future :)

Preview of:
- Bar Text Y Offset
- Icon X Offset (requires `/rl`)

https://user-images.githubusercontent.com/10605951/177220463-ff5be2d3-b8c6-426e-a0b0-d4879499db01.mp4

