### PR TITLE
Add awesomecvar skin

### DIFF
--- a/ElvUI_AddOnSkins/Skins/Addons/AwesomeCVar.lua
+++ b/ElvUI_AddOnSkins/Skins/Addons/AwesomeCVar.lua
@@ -1,0 +1,19 @@
+local E, L, V, P, G = unpack(ElvUI)
+local S = E:GetModule("Skins")
+local AS = E:GetModule("AddOnSkins")
+
+if not AS:IsAddonLODorEnabled("AwesomeCVar") then return end
+
+-- EPGP 5.5.19
+-- https://www.curseforge.com/wow/addons/epgp-dkp-reloaded/files/442647
+
+S:AddCallbackForAddon("AwesomeCVar", "AwesomeCVar", function()
+	if not E.private.addOnSkins.AwesomeCVar then return end
+	
+	GameMenuButtonAwesomeCVar:StripTextures()
+	S:HandleButton(GameMenuButtonAwesomeCVar)
+	--[[
+		тут надо писать много строк и скинить внутрянку всего аддона
+		когда-нибудь я этим займусь... наверное.
+	]]
+end)

--- a/ElvUI_AddOnSkins/Skins/Addons/load_addons.xml
+++ b/ElvUI_AddOnSkins/Skins/Addons/load_addons.xml
@@ -98,4 +98,5 @@
 	<Script file="RCLootCouncil.lua"/>
 	<Script file="QDKP2_GUI.lua"/>
 	<Script file="LootWonAlert.lua"/>
+	<Script file="AwesomeCVar.lua"/>AwesomeCVar
 </Ui>

--- a/ElvUI_AddOnSkins/core.lua
+++ b/ElvUI_AddOnSkins/core.lua
@@ -109,6 +109,7 @@ local addonList = {
 	"RCLootCouncil",
 	"QDKP2_GUI",
 	"LootWonAlert",
+	"AwesomeCVar",
 }
 local addonAlias = {
 	["DBM"] = "DBM-Core",
@@ -375,15 +376,8 @@ local function getOptions()
 								name = "Bar Height",
 								hidden = function() return DBM.ReleaseRevision > 7000 end
 							},
-							dbmBarTextYOffset = {
-								order = 2,
-								type = "range",
-								min = -5, max = 10, step = 1,
-								name = L["Bar Text Y-Offset"],
-								disabled = function() return not E.db.addOnSkins.DBMSkinHalf end
-							},
 							dbmFont = {
-								order = 3,
+								order = 2,
 								type = "select",
 								dialogControl = "LSM30_Font",
 								name = L["Font"],
@@ -391,14 +385,14 @@ local function getOptions()
 								hidden = function() return DBM.ReleaseRevision > 7000 end
 							},
 							dbmFontSize = {
-								order = 4,
+								order = 3,
 								type = "range",
 								min = 6, max = 22, step = 1,
 								name = L["Font Size"],
 								hidden = function() return DBM.ReleaseRevision > 7000 end
 							},
 							dbmFontOutline = {
-								order = 5,
+								order = 4,
 								type = "select",
 								name = L["Font Outline"],
 								values = {
@@ -410,26 +404,19 @@ local function getOptions()
 								hidden = function() return DBM.ReleaseRevision > 7000 end
 							},
 							dbmIconSize = {
-								order = 6,
+								order = 5,
 								type = "range",
 								min = 0.1, max = 2, step = 0.1,
 								name = L["Icon Size"],
 							},
-							dbmIconXOffset = {
-								order = 7,
-								type = "range",
-								min = -10, max = 10, step = 1,
-								name = L["Icon X-Offset"],
-								set = function(info, value) E.db.addOnSkins[info[#info]] = value E:StaticPopup_Show("PRIVATE_RL") end -- dbm skin should probably be recoded to avoid a UI reload for this option to apply.
-							},
 							dbmTemplate = {
-								order = 8,
+								order = 6,
 								type = "select",
 								name = L["Template"],
 								values = backdropValues
 							},
 							DBMSkinHalf = {
-								order = 9,
+								order = 7,
 								type = "toggle",
 								name = L["DBM Half-bar Skin"]
 							}

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ ElvUI_AddOnSkins is a plugin for [ElvUI](https://github.com/ElvUI-WotLK/ElvUI) w
 1. AtlasQuest
 1. Auctionator
 1. AuctioneerSuite
+1. AwesomeWotlk
 1. BigWigs
 1. BindPad
 1. BlackList


### PR DESCRIPTION
Adds initial skin support for AwesomeCVar.

- Registers AwesomeCVar in the core addon list
- Adds load script entry
- Skins the GameMenu button
- Tested on WotLK Stormforge
- Taken from user wwvwvwvvw on discrd

